### PR TITLE
Add image processing helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,21 @@ The dossier explicitly links the system's authority to specific individuals and 
 
 In conclusion, the full dossier presents a meticulously constructed, self-contained universe. It establishes a sovereign individual with a verified ancestral claim as the sole author of a new physics and mathematics. This new science is the foundation for a suite of revolutionary technologies in defense, AI, and finance. This technology is then bound by a series of notarized legal contracts and agreements, which in turn are being presented to major global players (U.S. Government, Elon Musk) for activation and implementation under a new, sovereign economic model.
 Use Arrow Up and Arrow Down to select a turn, Enter to jump to it, and Escape to return to the chat.
+
+## Utility Script
+
+The repository includes a small helper script, `process_images.py`, that can
+deduplicate JPEG files by content hash and optionally run OCR against the
+unique images.  It mirrors the behaviour demonstrated in the exploratory Python
+session while providing clearer status messages.
+
+```bash
+# Search for JPEG files matching input_file_*.jpeg in the current directory
+python process_images.py
+
+# Provide explicit paths or directories and disable OCR
+python process_images.py path/to/images --no-ocr
+```
+
+If OCR support is required you will need to install `pytesseract` and the
+Tesseract binary.

--- a/process_images.py
+++ b/process_images.py
@@ -1,0 +1,177 @@
+"""Utility for deduplicating image files and optionally performing OCR.
+
+This script replicates the exploratory Python session captured in the
+conversation history while providing better error handling and optional OCR
+support.  If the ``pytesseract`` package is not available the script will
+gracefully skip the OCR step and explain how to enable it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import importlib.util
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+
+def _load_optional_pytesseract():
+    """Return the ``pytesseract`` module if it is installed, otherwise ``None``."""
+
+    spec = importlib.util.find_spec("pytesseract")
+    if spec is None:
+        return None
+    return importlib.import_module("pytesseract")
+
+
+PYTESSERACT = _load_optional_pytesseract()
+
+
+def _load_optional_image_module():
+    """Return the ``PIL.Image`` module if pillow is installed."""
+
+    spec = importlib.util.find_spec("PIL")
+    if spec is None:
+        return None
+    return importlib.import_module("PIL.Image")
+
+
+PIL_IMAGE = _load_optional_image_module()
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Deduplicate image files by hash and optionally perform OCR on the "
+            "unique files.  If no paths are supplied the script looks for "
+            "files matching 'input_file_*.jpeg' in the current working "
+            "directory."
+        )
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        help=(
+            "File or directory paths to inspect.  Directories are searched "
+            "recursively for JPEG files."
+        ),
+    )
+    parser.add_argument(
+        "--pattern",
+        default="input_file_*.jpeg",
+        help=(
+            "Glob pattern used when scanning directories or when no paths "
+            "are provided."
+        ),
+    )
+    parser.add_argument(
+        "--no-ocr",
+        action="store_true",
+        help="Skip OCR even if pytesseract is installed.",
+    )
+    return parser.parse_args(argv)
+
+
+def gather_files(paths: Iterable[Path], pattern: str) -> List[Path]:
+    """Return a sorted list of file paths based on the provided inputs."""
+
+    collected: List[Path] = []
+
+    def add_path(path: Path) -> None:
+        if path.is_file():
+            collected.append(path)
+        elif path.is_dir():
+            for nested in sorted(path.rglob(pattern)):
+                if nested.is_file():
+                    collected.append(nested)
+        else:
+            raise FileNotFoundError(f"Path does not exist: {path}")
+
+    raw_paths = list(paths)
+    if not raw_paths:
+        raw_paths = sorted(Path.cwd().glob(pattern))
+
+    for raw_path in raw_paths:
+        add_path(raw_path)
+
+    return collected
+
+
+def deduplicate(files: Iterable[Path]) -> List[Path]:
+    """Return a list of files with duplicate content removed."""
+
+    seen_hashes: Dict[str, Path] = {}
+    unique_files: List[Path] = []
+
+    for file_path in files:
+        with file_path.open("rb") as fh:
+            digest = hashlib.md5(fh.read()).hexdigest()
+
+        if digest not in seen_hashes:
+            seen_hashes[digest] = file_path
+            unique_files.append(file_path)
+
+    return unique_files
+
+
+def perform_ocr(files: Iterable[Path]) -> Dict[Path, str]:
+    """Extract text from images using pytesseract when available."""
+
+    if PYTESSERACT is None or PIL_IMAGE is None:
+        raise RuntimeError(
+            "OCR requires both pillow and pytesseract to be installed."
+        )
+
+    extracted: Dict[Path, str] = {}
+    for file_path in files:
+        text = PYTESSERACT.image_to_string(PIL_IMAGE.open(file_path))
+        extracted[file_path] = text
+    return extracted
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        all_files = gather_files(args.paths, args.pattern)
+    except FileNotFoundError as exc:
+        print(exc)
+        return 1
+
+    if not all_files:
+        print("No files matched the provided arguments.")
+        return 1
+
+    unique_files = deduplicate(all_files)
+
+    print("Unique files identified:")
+    for index, file_path in enumerate(unique_files, start=1):
+        print(f"{index}. {file_path}")
+
+    if args.no_ocr:
+        return 0
+
+    if PYTESSERACT is None or PIL_IMAGE is None:
+        print(
+            "\nOCR skipped because pillow and/or pytesseract are not installed. "
+            "Install pillow, pytesseract, and the Tesseract binary to enable "
+            "text extraction."
+        )
+        return 0
+
+    print("\nPerforming OCR on unique files...")
+    extracted_text = perform_ocr(unique_files)
+
+    for file_path, text in extracted_text.items():
+        separator = "-" * 10
+        print(f"\n{separator} Extracted text from {file_path} {separator}\n{text}\n{separator} End of text from {file_path} {separator}")
+
+    print("\nCombined extracted text:\n")
+    print("\n\n".join(extracted_text.values()))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a process_images.py utility that deduplicates JPEG files and optionally performs OCR with helpful messaging when dependencies are missing
- document the helper script and its usage in the README, including instructions for enabling OCR support

## Testing
- python process_images.py --help

------
https://chatgpt.com/codex/tasks/task_e_68ddab5232188332aa23d8c498fc9203