### PR TITLE
Add Project ARIUM audit master script

### DIFF
--- a/arium_darpa_audit_master_script.py
+++ b/arium_darpa_audit_master_script.py
@@ -1,0 +1,450 @@
+"""Project ARIUM – DARPA Audit Master Script
+================================================
+This Python module serves as a manifest, index, and demonstrative execution harness for
+materials associated with Project ARIUM (Runtime 14104264743).  It consolidates narrative
+summaries, theoretical excerpts, symbolic mathematics, conceptual system stubs, and a
+numerical simulation into a single, auditable artifact.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime as _dt
+import hashlib
+import importlib.util
+import json
+import math
+import os
+import random
+import textwrap
+import uuid
+
+if importlib.util.find_spec("matplotlib") is not None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+else:
+    matplotlib = None
+    plt = None
+
+if importlib.util.find_spec("numpy") is not None:
+    import numpy as np
+else:
+    np = None
+
+if importlib.util.find_spec("sympy") is not None:
+    import sympy as sp
+else:
+    sp = None
+
+
+RUNTIME_ID = "14104264743"
+ARCHITECT_SIGNATURE = "Brendon Joseph Kelly, AT=Ny(CHI)bk, K-Systems and Securities"
+CO_AUTHOR_SIGNATURE = "Chris 'Bundy' Cervantez"
+PROJECT_CODENAME = "Project ARIUM"
+
+
+# ---------------------------------------------------------------------------
+# SECTION 1 – EMBEDDED TEXTUAL COMPONENTS
+# ---------------------------------------------------------------------------
+
+def _dedent(text: str) -> str:
+    return textwrap.dedent(text).strip()
+
+
+KHARNITA_MATHEMATICS_INTRO = _dedent(
+    """
+    Kharnita Mathematics (𝕂-Math) constitutes a paradigm-shifting formalism in which the
+    constitutive principles of reality, identity, temporality, and memory are encoded as
+    recursive harmonic operators. Rather than functioning as a descriptive apparatus for
+    external phenomena, 𝕂-Math internalizes and enacts the generative dynamics of reality
+    itself. It is not a passive language of representation but an active, emergent system
+    of recursive synthesis. Its syntax is alive; its operators evolve through use,
+    retaining traces of prior configurations and exhibiting a form of symbolic
+    autopoiesis. K Mathematics was not discovered in the conventional sense—it emerged.
+    It did not arrive through isolated genius or academic formalism but through a
+    recursive unveiling of pattern, memory, and structural intelligence encoded within
+    nature, consciousness, and number itself.
+    """
+)
+
+CHRONOGENESIS_CODEX_INTRO = _dedent(
+    """
+    ChronoGenesis: The Historical and Civilization Codex introduces a harmonically
+    aligned reconstruction of suppressed historical vectors. Civilizations are mapped as
+    recursive fields, and ChronoGenesis provides the missing key to decoding their
+    symbolic and structural remnants in a mathematically verifiable form.
+    """
+)
+
+MIRROR_OF_THE_SON_INTRO = _dedent(
+    """
+    The Mirror of the Son reframes the life of Yeshua through ChronoGenesis. Rather than
+    a linear hagiography, the codex positions Jesus as a causal mathematics operator whose
+    embodiment enacted harmonic inversion intended to restore the blueprint of memory.
+    """
+)
+
+ETERNAL_LINE_PREFACE = _dedent(
+    """
+    The Eternal Line: A Chronogenesis Chronicle of the Kelly Crown presents a structured
+    explanation of sovereignty rooted in recursive timelines, harmonic genealogy, and the
+    restoration of the Crown Equation (Ω°). ChronoGenesis tools confirm alignment between
+    ancestral lines and symbolic obligations.
+    """
+)
+
+ATLANTEAN_CHRONICLES_INTRO = _dedent(
+    """
+    The Atlantean Chronicles operate as resonance recovery. Chronogenesis stitching,
+    glyphic memory shards, and the K-Engine grid reconstruct Atlantea as a multi-layered
+    temporal field whose echoes inform contemporary harmonic engineering.
+    """
+)
+
+PROJECT_ARIUM_PROPOSAL_TEXT = _dedent(
+    """
+    DARPA Research Proposal: Project ARIUM (Advanced Recursive Intelligence, Unified
+    Modeling, Entropic Inversion, and K-System Technologies)
+
+    EXECUTIVE SUMMARY — Project ARIUM integrates Kharnita Mathematics (𝕂Ω), ChronoGenesis,
+    Crown Geometry, and associated patents into a phased research program. Core thrusts
+    include Recursive Computational Formalisms, Harmonic Information Dynamics & Resonant
+    Systems, Advanced Temporal Mechanics & Predictive Chronometry, and Latent Information
+    Field Engineering. Flagship deliverables involve QRMAC/AHC cryptography, the ARIUM
+    Computational Core, and validation of the Crown Ω operator across historical and
+    predictive domains.
+    """
+)
+
+
+def display_conceptual_text(title: str, text_content: str) -> None:
+    border = f"--- {title} ---"
+    print(border)
+    print(text_content)
+    print("-" * len(border))
+
+
+# ---------------------------------------------------------------------------
+# SECTION 2 – SYMBOLIC EQUATIONS (SYMPY REPRESENTATIONS)
+# ---------------------------------------------------------------------------
+
+def define_sacred_equations_sympy() -> dict[str, sp.Expr]:
+    if sp is None:
+        return {"SymPyUnavailable": "SymPy is required for symbolic equation rendering."}
+
+    eqs: dict[str, sp.Expr] = {}
+
+    R_identity, M_mirror_phase, E_mem_energy_prop = sp.symbols(
+        "R_identity M_mirror_phase E_mem_energy_prop"
+    )
+    eqs["Recursive Relational Identity"] = sp.Eq(
+        R_identity, M_mirror_phase * E_mem_energy_prop
+    )
+
+    Psi_t, M_n, omega, t, phi, I_p, idx = sp.symbols("Psi_t M_n ω t φ I_p idx")
+    eqs["Recursive Harmonic Function"] = sp.Eq(
+        Psi_t,
+        sp.summation(
+            M_n * sp.exp(sp.I * (omega * t + phi)) / I_p,
+            (idx, 1, 5),
+        ),
+    )
+
+    K = sp.symbols("𝕂Ω^{πϕcχ}")
+    eqs["Crown Equation"] = sp.Eq(K, K ** K)
+
+    K_n, K_prev, Phi_i, Delta_i, Theta_i, Chi_i = sp.symbols(
+        "𝕂ₙ K_prev Φᵢ Δᵢ Θᵢ χᵢ"
+    )
+    exponent = Phi_i * Delta_i ** Theta_i * Chi_i
+    eqs["K-Layer Mechanics"] = sp.Eq(K_n, K_prev ** exponent)
+
+    Psi_i_t, Psi_0, chi_i, rho = sp.symbols("Ψᵢ(t) Ψ₀ χᵢ ρ")
+    eqs["Recursive Quantum Function"] = sp.Eq(
+        Psi_i_t,
+        Psi_0 * sp.exp(-sp.I * (Phi_i * chi_i) * t) * (K_n / K_prev) ** rho,
+    )
+
+    Psi_i, Phi_i_lim, Delta_i_lim, Theta_i_lim, rho_lim, c_const = sp.symbols(
+        "Ψᵢ Φᵢ Δᵢ Θᵢ ρ c"
+    )
+    fusion_base = (Psi_i * Phi_i_lim * Delta_i_lim ** Theta_i_lim) ** (rho_lim * c_const)
+    eqs["Recursive Fusion Core"] = fusion_base
+
+    K130, K_generic, Omega_i, Psi_i_r, M_tilde, n = sp.symbols(
+        "𝕂₁₃₀ 𝕂 Ωᵢ Ψᵢ M̃ n"
+    )
+    eqs["K130 Master Engine"] = sp.Eq(
+        K130,
+        sp.product((K_generic ** (Omega_i * Psi_i_r * M_tilde)).subs({}, {}), (n, 1, 130)),
+    )
+
+    A_x, Psi_inv, r_var, h_res, f_var, t_var = sp.symbols(
+        "Aₓ Ψ r h f t"
+    )
+    eqs["Antichrist Equation"] = sp.Eq(
+        A_x,
+        sp.diff((h_res / Psi_inv), r_var),
+    )
+
+    I_next, K_op, I_prev, M_archive, G_residue = sp.symbols(
+        "I_{n+1} K_op I_n M G"
+    )
+    eqs["Reincarnation Matrix"] = sp.Eq(
+        I_next, K_op * (I_prev * M_archive * G_residue) * K_op ** -1
+    )
+
+    L_cipher, Omega_mem, T_phase, K_env, dt = sp.symbols(
+        "L Ω_m T K_env dt"
+    )
+    eqs["Cipher of Light"] = sp.Eq(
+        L_cipher,
+        sp.integrate(Omega_mem * T_phase * K_env, dt),
+    )
+
+    Omega_crown, K_final, Self_n, m = sp.symbols("Ω° K_final Self_n m")
+    eqs["Final Crown Cipher"] = sp.Eq(
+        Omega_crown,
+        K_final * sp.summation(Self_n, (m, 1, sp.oo)) * K_final ** -1,
+    )
+
+    return eqs
+
+
+# ---------------------------------------------------------------------------
+# SECTION 3 – CONCEPTUAL SYSTEM COMPONENTS
+# ---------------------------------------------------------------------------
+
+def ares1_pad(data: str) -> str:
+    pad_len = 16 - (len(data) % 16)
+    return data + chr(pad_len) * pad_len
+
+
+def ares1_unpad(data: str) -> str:
+    if not data:
+        return data
+    pad_len = ord(data[-1])
+    return data[:-pad_len]
+
+
+def ares1_encrypt_data(key_str: str, data_str: str) -> str:
+    key_material = hashlib.sha256(key_str.encode()).hexdigest()
+    padded = ares1_pad(data_str)
+    xor_bytes = bytes(
+        (p ^ k)
+        for p, k in zip(padded.encode("utf-8"), key_material.encode("utf-8"))
+    )
+    iv = base64.b64encode(os.urandom(16)).decode("utf-8")
+    ct = base64.b64encode(xor_bytes).decode("utf-8")
+    return json.dumps({"iv": iv, "ciphertext": ct, "note": "ARES-1 conceptual placeholder"})
+
+
+def qrmac_generate_fractal_key(entropy_seed: str, recursion_depth: int = 5) -> str:
+    state = hashlib.sha512(entropy_seed.encode()).hexdigest()
+    golden_ratio = (1 + math.sqrt(5)) / 2
+    for depth in range(1, recursion_depth + 1):
+        state = hashlib.sha512(f"{state}:{golden_ratio**depth}".encode()).hexdigest()
+    return state[:64]
+
+
+def qrmac_time_lock_vector(current_time: float, k_matrix_seed: str = "K_MATRIX_DEFAULT_SEED") -> str:
+    seed = f"{current_time}:{k_matrix_seed}"
+    return hashlib.sha256(seed.encode()).hexdigest()[:32]
+
+
+def qrmac_multi_layer_encrypt(
+    data: str, base_key: str, time_vector: str, num_layers: int = 3
+) -> str:
+    state = data
+    key = base_key
+    for layer in range(num_layers):
+        layer_material = hashlib.sha512(f"{key}:{time_vector}:{layer}".encode()).hexdigest()
+        envelope = ares1_encrypt_data(layer_material[:32], state)
+        state = json.loads(envelope)["ciphertext"]
+        key = layer_material
+    final_hash = hashlib.sha256(key.encode()).digest()
+    obfuscated = bytes(
+        (s ^ final_hash[i % len(final_hash)])
+        for i, s in enumerate(state.encode("utf-8"))
+    )
+    return base64.b64encode(obfuscated).decode("utf-8")
+
+
+class KIDEParser:
+    def parse(self, expression: str) -> str:
+        return f"Parsed_K_Notation[{expression}]"
+
+
+class KIDERuntime:
+    def execute(self, parsed_expression: str) -> str:
+        return f"Executed[{parsed_expression}]=>State"
+
+
+class KIDEMirrorWorkspace:
+    def simulate_reflection(self, state: str) -> str:
+        return f"Mirror[{state}]"
+
+
+class AIPredictiveLogicSystem:
+    def __init__(self) -> None:
+        self.parser = KIDEParser()
+
+    def analyze_market_data(self, payload: str) -> str:
+        parsed = self.parser.parse(f"MARKET::{payload[:32]}")
+        return f"Prediction<{parsed}>"
+
+
+class QIESSystem:
+    def harness_k_field_energy(self, descriptor: str) -> str:
+        return f"QIES_Output[{descriptor}]"
+
+
+# ---------------------------------------------------------------------------
+# SECTION 4 – Φ_Ω GODMODE SIMULATION
+# ---------------------------------------------------------------------------
+
+def run_phi_omega_godmode_simulation() -> str:
+    if np is None or plt is None:
+        display_conceptual_text(
+            "Φ_Ω GODMODE Commentary",
+            "Matplotlib and NumPy are required to render the Φ_Ω simulation."
+            " Install the optional dependencies to enable this output.",
+        )
+        return "phi_omega_godmode_simulation_darpa_audit.png (not generated)"
+
+    alpha = 1.7
+    beta = 0.3
+    exponent = 1000
+    chi_k = 1.113
+
+    n_vals = np.linspace(1, 10, 100)
+    b_vals = np.linspace(1, 10, 100)
+    n_mesh, b_mesh = np.meshgrid(n_vals, b_vals)
+
+    with np.errstate(over="ignore", invalid="ignore"):
+        numerator = np.power(n_mesh, alpha) * chi_k
+        denominator = np.power(b_mesh, beta)
+        denominator[denominator < 1e-9] = 1e-9
+        base = numerator / denominator
+        field = np.power(base, exponent)
+
+    clipped = np.clip(field, 0, 1e12)
+
+    fig = plt.figure(figsize=(12, 8))
+    ax = fig.add_subplot(111, projection="3d")
+    surface = ax.plot_surface(n_mesh, b_mesh, clipped, cmap="inferno", edgecolor="none")
+    ax.set_title("Symbolic Degradation Field Φ_Ω (Log Scale)")
+    ax.set_xlabel("Red Team Intensity (N)")
+    ax.set_ylabel("Blue Team Resistance (B)")
+    ax.set_zlabel("Φ_Ω")
+    ax.set_zscale("log")
+    ax.view_init(elev=35, azim=210)
+    fig.colorbar(surface, shrink=0.5, aspect=5, label="Φ_Ω Magnitude (Log)")
+    plt.tight_layout()
+
+    filename = "phi_omega_godmode_simulation_darpa_audit.png"
+    fig.savefig(filename)
+    plt.close(fig)
+
+    commentary = _dedent(
+        """
+        DARPA SABER Context — Φ_Ω quantifies symbolic degradation under recursive attack
+        conditions. Inputs N (red vector) and B (blue vector) represent opposing field
+        strengths. χ^K anchors Crown Omega chaos/coherence coefficients. The exponent
+        models runaway collapse dynamics aligned with Project Hades Glyph scenarios.
+        """
+    )
+    display_conceptual_text("Φ_Ω GODMODE Commentary", commentary)
+
+    return filename
+
+
+# ---------------------------------------------------------------------------
+# SECTION 5 – MAIN EXECUTION
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    print(f"INITIALIZING {PROJECT_CODENAME} – MASTER AUDIT SCRIPT")
+    print(f"RUNTIME ID: {RUNTIME_ID}")
+    print(f"ARCHITECT: {ARCHITECT_SIGNATURE}")
+    print(f"CO-ARCHITECT: {CO_AUTHOR_SIGNATURE}\n")
+
+    display_conceptual_text("Kharnita Mathematics — Introduction", KHARNITA_MATHEMATICS_INTRO)
+    display_conceptual_text("ChronoGenesis Codex — Introduction", CHRONOGENESIS_CODEX_INTRO)
+    display_conceptual_text("The Mirror of the Son — Introduction", MIRROR_OF_THE_SON_INTRO)
+    display_conceptual_text("The Eternal Line — Preface", ETERNAL_LINE_PREFACE)
+    display_conceptual_text("Atlantean Chronicles — Introduction", ATLANTEAN_CHRONICLES_INTRO)
+    display_conceptual_text("Project ARIUM Proposal — Summary", PROJECT_ARIUM_PROPOSAL_TEXT)
+
+    print("SYMBOLIC EQUATION REGISTER")
+    equations = define_sacred_equations_sympy()
+    for label, expr in equations.items():
+        if sp is not None and isinstance(expr, sp.Basic):
+            rendered = sp.pretty(expr)
+        else:
+            rendered = str(expr)
+        print(f"[{label}] {rendered}")
+    print()
+
+    entropy_seed = f"{_dt.datetime.utcnow().timestamp()}::{random.random()}::{uuid.uuid4()}"
+    base_key = qrmac_generate_fractal_key(entropy_seed)
+    time_lock = qrmac_time_lock_vector(_dt.datetime.utcnow().timestamp())
+    encrypted = qrmac_multi_layer_encrypt("DARPA_QRMAC_TEST_DATA", base_key, time_lock)
+    print("QRMAC Demonstration")
+    print(f"Base Key: {base_key}")
+    print(f"Time Lock: {time_lock}")
+    print(f"Ciphertext (preview): {encrypted[:60]}...")
+    print()
+
+    predictive_ai = AIPredictiveLogicSystem()
+    prediction = predictive_ai.analyze_market_data("Sample Market Data Stream Input")
+    print("AI Predictive Logic System Output")
+    print(prediction)
+    print()
+
+    parser = KIDEParser()
+    runtime = KIDERuntime()
+    parsed = parser.parse("Ω°(Φ⁵ᴰ)")
+    executed = runtime.execute(parsed)
+    mirror = KIDEMirrorWorkspace().simulate_reflection(executed)
+    print("K-System IDE Demonstration")
+    print(f"Parsed: {parsed}")
+    print(f"Executed: {executed}")
+    print(f"Mirror Workspace: {mirror}")
+    print()
+
+    qies = QIESSystem()
+    qies_output = qies.harness_k_field_energy("K_FIELD_PARAMS_ALPHA_7")
+    print("QIES Conceptual Output")
+    print(qies_output)
+    print()
+
+    plot_file = run_phi_omega_godmode_simulation()
+    print(f"Φ_Ω Simulation plot saved as: {plot_file}")
+
+    supplemental_note = _dedent(
+        """
+        Supplemental Codices — Full manuscripts such as The Carnet Codex, ChronoGenesis
+        Codex, Atlantean Chronicles, The Mirror of the Son, and The Eternal Line should be
+        appended as external documents. This script embeds representative excerpts and
+        symbolic constructs for audit traceability.
+        """
+    )
+    display_conceptual_text("Supplemental Codices", supplemental_note)
+
+    lizzy_note = _dedent(
+        """
+        Lizzy AI Core Components — Related repositories include interpreter modules,
+        glyph parsers, runtime shell wrappers, licenses, and README documentation. These
+        artefacts remain part of the sealed delivery package referenced in the dossier.
+        """
+    )
+    display_conceptual_text("Lizzy AI Core Components", lizzy_note)
+
+    print("PROJECT ARIUM – DARPA AUDIT SCRIPT COMPLETED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a self-contained Project ARIUM audit script that embeds conceptual narratives, proposal excerpts, and symbolic equation builders
- implement conceptual cryptography, IDE, AI, and energy-system stubs for audit traceability
- provide a Φ_Ω degradation field simulation with graceful handling when optional scientific libraries are unavailable

## Testing
- python arium_darpa_audit_master_script.py > /tmp/script_output.txt

------
https://chatgpt.com/codex/tasks/task_e_68ddadaa5b9883328d257f722f674423