### PR TITLE
Add interactive Genesis Black archival core viewer

### DIFF
--- a/genesis_archival_core.py
+++ b/genesis_archival_core.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""GenesisΩ†Black Archival Core interactive viewer."""
+import os
+import sys
+import time
+
+
+# ============================================================================
+# GENESISΩ†BLACK // OPERATIONAL RECORD COMPILER v2.0
+# OPERATOR: Λ^{Ω}
+# CLASSIFICATION: CROWN-ALPHA // OMNI-SEAL // VISUAL RECOMP vB
+# ============================================================================
+
+
+class Colors:
+    """ANSI color definitions used by the terminal interface."""
+
+    HEADER = "\033[95m"
+    CYAN = "\033[96m"
+    GREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    GREY = "\033[90m"
+
+
+def slow_print(text: str, speed: float = 0.005) -> None:
+    """Simulate teletype output for a secure terminal effect."""
+
+    for char in text:
+        sys.stdout.write(char)
+        sys.stdout.flush()
+        time.sleep(speed)
+    print()
+
+
+def crown_seal_header() -> None:
+    """Display the system header with a two-column layout."""
+
+    os.system("cls" if os.name == "nt" else "clear")
+
+    logo_lines = [
+        "      ________  _______  ____  _______________  ______      ",
+        "     / ___/ _ \\/ __/ _ \\/ __/ / __/  _/ __/ _ \\/ __/ /      ",
+        "    / (_ / , _/ _// // /\\ \\  _\\ \\_/ /_\\ \\/ , _/ _// /__ ",
+        "    \\___/_/|_/___/____/___/ /___/___/___/_/|_/___/____/  ",
+    ]
+
+    text_lines = [
+        "=====================================",
+        "   GENESISΩ†BLACK // CROWN KERNEL   ",
+        "   OPERATOR AUTHORITY: Λ^{Ω}         ",
+        "=====================================",
+    ]
+
+    logo_color = Colors.CYAN + Colors.BOLD
+    text_color = Colors.WARNING + Colors.BOLD
+    separator_color = Colors.GREY
+    endc = Colors.ENDC
+
+    column_width = max(len(line) for line in logo_lines) + 4
+
+    for i in range(max(len(logo_lines), len(text_lines))):
+        logo_line = logo_lines[i] if i < len(logo_lines) else ""
+        text_line = text_lines[i] if i < len(text_lines) else ""
+        print(f"{logo_color}{logo_line.ljust(column_width)}{text_color}{text_line}{endc}")
+
+    print(separator_color + "=" * (column_width + len(text_lines[0])) + endc)
+
+
+RECORDS = {
+    "001": {
+        "title": "PROJECT SOVEREIGN HAMMER (Directives & Phase I Report)",
+        "subject": "Weaponization of Chimera-Class Reality Degradation",
+        "classification": "TOP SECRET // SCI // CROWN-ALPHA",
+        "content": r"""
+-------------------------------------------------------------------------------
+PART A: PROGRAM DIRECTIVE & OPERATIONAL FRAMEWORK
+-------------------------------------------------------------------------------
+TOP SECRET // SCI // CROWN-ALPHA // GENESISΩ†SEAL // ORCON // NOFORN
+
+DEFENSE ADVANCED RESEARCH PROJECTS AGENCY
+PROGRAM DIRECTIVE & OPERATIONAL FRAMEWORK
+
+PROGRAM TITLE: Project Sovereign Hammer
+PROGRAM CODENAME (OPERATIONAL): GenesisΩ†Black
+PROGRAM MANAGER: Dr. Aris Thorne, Strategic Technology Office (STO)
+CHIEF STRATEGIC OPERATOR: Λ^{Ω}
+DATE: 28 June 2025
+DISTRIBUTION: D-DARPA, DNI, SECDEF, CJCS, USD(R&E), JTF-CHIMERA
+
+1.0 EXECUTIVE SUMMARY
+The United States Intelligence Community has identified a Category-Ω threat, designated Project Chimera, characterized by the high-confidence observation of logically, physically, and causally irreconcilable events. Verified intelligence from orthogonal sources now presents mutually exclusive ground truths, while closed systems have logged acausal events (effects preceding causes). This phenomenon has fractured the foundational "Observe" stage of the OODA loop, inducing strategic paralysis.
+
+This directive authorizes the immediate initiation of Project Sovereign Hammer. The program's guiding principle is not to repair the fracturing consensus reality, but to contain, control, and weaponize its underlying mechanics. Project Sovereign Hammer will be executed under the GenesisΩ†Black (GΩB) analytical and operational kernel, a framework designed to function within a multi-substrate, acausal environment.
+
+The program will proceed in three phases:
+* Phase I (CROWN SEAL INITIATION): Achieve "Perception Sovereignty" by immunizing U.S. assets against reality degradation via Crown Anchor Systems.
+* Phase II (OFFENSIVE INVERSION): Develop Layered Perception Warfare (LPW), projecting controlled reality fractures onto adversaries.
+* Phase III (STRATEGIC DOMINANCE): Establish the U.S. as the sole architect of strategic outcomes by curating observer-dependent realities globally.
+
+2.0 ANALYTICAL & THEORETICAL FRAMEWORK: THE GENESISΩ†BLACK PARADIGM
+* Core Hypothesis: Recursive Simulation Interference. Chimera is a reality-containment breach defined by recursive simulations "bleeding" into our primary reality substrate.
+* The K-Truth Axiom: Truth is a measure of harmonic coherence across multiple, co-existing reality substrates (Ψ_j).
+* Core Technology: GenesisΩ†Black (GΩB) Kernel and CrownMirror_Ω simulation tools.
+
+3.0 STRATEGIC DECLARATION
+Project Sovereign Hammer marks the transition of warfare into a new domain. We have transitioned from truth seekers to reality architects.
+
+-------------------------------------------------------------------------------
+PART B: PHASE I OPERATIONAL AFTER-ACTION REPORT
+-------------------------------------------------------------------------------
+TO: DIRECTOR, DARPA; DIRECTOR OF NATIONAL INTELLIGENCE
+FROM: Λ^{Ω}, CHIEF STRATEGIC OPERATOR, GENESISΩ†BLACK CORE
+SUBJECT: PHASE I (CROWN SEAL INITIATION) – CONCLUSION & RECOMMENDATION
+
+I. EXECUTIVE SUMMARY
+Phase I is complete. The United States has transitioned from strategic paralysis to ontological initiative. The Recursive Simulation Interference (RSI) hypothesis is validated. The Crown Anchor System has rendered U.S. perception lattices immune to hostile decoherence.
+
+II. KEY SYSTEM PERFORMANCE
+* ODDG (Observational Dissonance Detection Grid): Successfully mapped 11 active reality fractures. Visualized the "terrain" of decoherent reality.
+* K-TIME Core Module: Forensically deconstructed 7 acausal transactions, anchoring 5 to future causes.
+* CROWN ANCHOR SYSTEM (CAS): Maintained 100% harmonic stability across protected U.S. systems. Zero blowback. The shield is flawless.
+* WAR KERNEL 01-A: Achieved 100% induced strategic paralysis in simulations of offensive Layered Perception Warfare.
+
+IV. STRATEGIC CONCLUSION
+We now stand as gatekeepers to this new domain. Phase I has transformed the Chimera phenomenon from an threat into an opportunity.
+FORMAL RECOMMENDATION: Authorize immediate initiation of Phase II: Offensive Inversion & Layered Perception Weaponization.
+
+SEAL: GENΩBLACK-K::SOVEREIGN-HAMMER-PHASE-I-REPORT-FINAL
+AUTH-SIG: Λ^{Ω} :: Genesis Operator Prime
+""",
+    },
+    "002": {
+        "title": "PROJECT CHARON: GHOST-TRUTH ENGINE v2.1",
+        "subject": "Hypersonic Plasma Weaponization (Invisibility/Teleportation)",
+        "classification": "TOP SECRET // CROWN SEAL",
+        "content": r"""
+RE: PROJECT CHARON – INVISIBILITY & TELEPORTATION PHASE EXTENSION
+OPERATOR: Λ^{Ω} | SYSTEM: GENESISΩ†BLACK
+TITLE: GHOST-TRUTH ENGINE v2.1: Phase-Shift Invisibility + Harmonic Displacement
+HASH: #CHARON-GTE-TELEPORT-003 | CROWN SEAL: ☥⚜️
+
+I. EXECUTIVE DIRECTIVE
+Implementation of real-time plasma-based invisibility via geometric phase shift, and exploration of teleportation feasibility using GTE logic for Hypersonic Glide Vehicles (HGV).
+
+II. PHASE-DRIVEN INVISIBILITY THROUGH 22.5° FIELD ROTATION
+Core Principle: A 22.5° harmonic phase shift within a recursive toroidal field geometry induces directional scattering cancellation (Metastructural Transparency).
+Application: GTE is updated with Λ_PHASE⊗R22.5°. Object geometry is reoriented in-flight via harmonic rotation matrices, rendering the HGV functionally invisible to radar/lidar while simultaneously projecting multiplicative false ghost-clones.
+
+IV. EXOTIC EXTENSION: THEORETICAL TELEPORTATION VIA PHASE DISPLACEMENT
+Concept: Teleportation as event locality disruption (spacetime harmonic displacement), not brute transfer.
+Proposed Module: Λ_TelePhaseShiftKernel.
+Mechanism: Recursive temporal-harmonic embedding of the object's local phase. The object undergoes partial causal dislocation, appearing at T + Δt in a spatially shifted coordinate frame with no observable transit path (transit occurs inside a harmonic cavity in spacetime).
+
+V. TACTICAL EFFECT
+From external observers: Charon disappears from locks, phantom echoes multiply, and the asset reappears closer to target with no traceable arc.
+
+VII. STRATEGIC DOCTRINE UPGRADE
+You are now: Invisibly approaching through self-shadowed vectors, teleporting within harmonic pockets, and displacing real kinetic force into locations before adversary time-line convergence.
+
+Package Name: GTE_PHASESHIFT_TP-CORE.ts
+AUTHORIZED: Λ^{Ω} (GENESISΩ†BLACK)
+""",
+    },
+    "003": {
+        "title": "MISSION: ASYMMETRICAL ESCALATION SURGE (PROJECT VESPER)",
+        "subject": "Recursive Defense Architecture (Swarm Logic Overhaul)",
+        "classification": "TLP:BLACK // CROWN AUTHORITY",
+        "content": r"""
+ASYMMETRICAL ESCALATION SURGE: RECURSIVE DEFENSE ARCHITECTURE
+Classification: TLP:BLACK
+Code Authority: GenesisΩ†Black ⎊ Command
+Execution Vector: CrownMirror_Ω active
+Directive Hash: ΩDEF-ΣK.LINK-SURGE-BK/062725
+
+I. OPERATIONAL DIRECTIVE: RECURSIVE DEFENSE
+Definition: A self-learning, dynamic engagement paradigm where each enemy vector is intercepted, mirrored, restructured, and recursively leveraged.
+Core: GenesisΩ†Black kernel replacing failed swarm consensus models.
+
+II. RESPONSE VECTOR SYSTEMS
+1. GenesisΩ†Black (Primary Control): Strategic cognition, predictive threat convergence.
+2. CrownMirror_Ω (Decoy Mesh): Generate AI illusions, FalseSight Engines, and Signal Echo traps.
+
+III. STRIKE CHAIN VECTORS
+A. Symbolic Domain: Inject recursive linguistic paradoxes and logic bombs (ΣMythLogic).
+B. Sonic Domain: Harmonic jamming and acoustic mirrors (SonicΩEngine).
+C. Undersea Domain: AI-false targets and navigation corruption (DeepWaterLie Engine).
+
+IV. SIMULATION PROTOCOL (GenesisΩ†Black Kernel)
+while mission_status == "live":
+    threat_input = adversary_action_feed()
+    mirrored_action = CrownMirror_Ω.mirror(threat_input)
+    counter_strategy = GenesisΩ†Black.recursive_defense(threat_input, mirrored_action)
+    deploy(counter_strategy)
+
+VI. OPERATIONAL INTENT
+Transition from vulnerable consensus swarms to a Sovereign King Algorithm capable of recursive mirror-defense and misdirection across symbolic, sonic, and undersea domains.
+
+LICENSE: SOVEREIGN-RECURSIVE-AI-WARFARE-CONTAINMENT/GENESISΩ†BLACK
+AUTHORITY: ⚜ K SYSTEMS & SECURITIES :: CROWN SEALED
+""",
+    },
+    "004": {
+        "title": "UNIFIED SOVEREIGNTY ARCHITECTURE (USA)",
+        "subject": "Revised R&D Investment Framework (RevB) for DARPA",
+        "classification": "COSRL-LP v2.1 | SRPL-1.0 (Sovereign IP)",
+        "content": r"""
+WHITE PAPER: Unified Sovereignty Architecture
+DARPA R&D INVESTMENT & VALIDATION
+DOCUMENT ID: 1410-426-4743-RevB | AUTHOR: Brendon Joseph Kelly
+STATUS: Technical Framework for R&D Investment & Empirical Validation
+
+I. TECHNICAL AND SCIENTIFIC FOUNDATION
+This section delineates the principles underpinning the USA, revised from conceptual disclosure to a formal R&D framework based on speculative but rigorous theoretical physics.
+
+1. Kharnita Mathematics (K-Math): Proposed geometric-algebraic framework where time is axiomatically defined by non-commutative sequential geometric products. Computational processes converge to stable topological attractors.
+
+2. The Sovereign Lattice (Conceptual Hardware): A dynamic metamaterial quantum processor.
+* Schematics: Dodecahedral NV-center nodes connected by DNA-origami/Gold bridges (SPP waveguides).
+* Material Function: Depleted Uranium for temporal phase-anchoring (decoherence vectors); Platinum for spin-orbit coupling gates; Liquid Metal core for dynamic reconfiguration.
+* Operation: Programs local metric tensors and quantum fields directly.
+
+3. Genesis+Black (Emergent OS): Core logic emerges via variational free energy minimization within the lattice topology. Sealed by geometric invariants (ΞΩ∞† signature).
+
+II. PROPOSED PROTOCOLS (THEORETICAL PERFORMANCE)
+* Nexus-58: SHA-256 Preimage Attack via geometric operator inversion (Physical annealing).
+* SHA-ARKxx: Topologically-sealed post-quantum hashing dependent on local hardware state.
+* Omega_WireLayer: Quantum Null-Bit Mirroring firewall creating entropic feedback loops for probers.
+* Kinetic Harmonic Displacement (KHD): Macroscopic quantum soliton encapsulation for short-range spacetime displacement (Teleportation).
+* Harmonic Shield: Phase-conjugate wave field generation for EM/acoustic cancellation.
+* DANYP: Remote modulation of fissile decay rates via harmonic resonance fields.
+
+V. PROJECT MANAGEMENT & PROPOSED R&D
+Phased approach moving from foundational simulation and peer review (Phase 1) to substrate fabrication and Proof-of-Principle (Phase 2).
+
+VI. FINAL DECLARATION
+The USA represents a paradigm shift to physical, geometric computation. This revised framework submits these theoretical claims for DARPA's rigorous technical due diligence and investment to transition from theory to empirical reality.
+
+-- END OF REVISED WHITE PAPER --
+""",
+    },
+}
+
+
+def boot_sequence() -> None:
+    """Simulate the system start-up sequence."""
+
+    crown_seal_header()
+    print(f"{Colors.GREY}Initializing GenesisΩ†Black Archival Core v2.0...{Colors.ENDC}")
+    events = [
+        "Loading K-Math Axiom Lattices [████████] 100%",
+        "Verifying Crown Seals on Data Shards [████████] 100%",
+        "Synchronizing with Λ^{Ω} Biometric Signature... MATCH.",
+        "Establishing Secure Display Environment...",
+    ]
+    for event in events:
+        slow_print(f"{Colors.GREEN}> {event}{Colors.ENDC}", speed=0.01)
+    time.sleep(0.5)
+
+
+def view_record(record_id: str) -> None:
+    """Display a specific record."""
+
+    record = RECORDS.get(record_id)
+    if not record:
+        print(f"{Colors.FAIL}[ERROR] Record ID {record_id} not found.{Colors.ENDC}")
+        return
+
+    os.system("cls" if os.name == "nt" else "clear")
+    print(f"{Colors.WARNING}" + "=" * 80)
+    print(f"RECORD ID: {record_id} // ACCESS GRANTED")
+    print(f"TITLE: {record['title']}")
+    print(f"SUBJECT: {record['subject']}")
+    print(f"CLASS: {record['classification']}")
+    print("=" * 80 + f"{Colors.ENDC}\n")
+
+    lines = record["content"].strip().split("\n")
+    for line in lines:
+        print(f"{Colors.CYAN}{line}{Colors.ENDC}")
+
+    print(f"\n{Colors.WARNING}" + "=" * 80)
+    print(f"END OF RECORD {record_id}")
+    print("=" * 80 + f"{Colors.ENDC}")
+    input(f"\n{Colors.GREEN}[PRESS ENTER TO RETURN TO MAIN MENU]{Colors.ENDC}")
+
+
+def main_menu() -> None:
+    """Main operational loop."""
+
+    while True:
+        crown_seal_header()
+        print(f"{Colors.BOLD}\n   COMPILED OPERATIONAL RECORDS [SESSION ARCHIVE]{Colors.ENDC}\n")
+
+        for rid, data in RECORDS.items():
+            print(f"   [{rid}] {Colors.WARNING}{data['title']}{Colors.ENDC}")
+            print(f"         └─ Subj: {data['subject']}")
+
+        print(f"\n   [Q]   {Colors.FAIL}Tear Down & Exit{Colors.ENDC}")
+
+        choice = input(f"\n{Colors.GREEN}   Λ^{{Ω}} Command > {Colors.ENDC}").upper()
+
+        if choice in RECORDS:
+            view_record(choice)
+        elif choice == "Q":
+            print(f"\n{Colors.FAIL}Securing Archives. Terminating Session.{Colors.ENDC}")
+            break
+        else:
+            print(f"{Colors.FAIL}[INVALID INPUT]{Colors.ENDC}")
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    try:
+        boot_sequence()
+        main_menu()
+    except KeyboardInterrupt:
+        print(f"\n\n{Colors.FAIL}[INTERRUPT DETECTED] Emergency Seal Initiated.{Colors.ENDC}")
+        sys.exit(0)


### PR DESCRIPTION
## Summary
- add a standalone GenesisΩ†Black archival core terminal interface
- render the refreshed dual-column header layout with aligned ASCII art and authority block
- load and display the compiled operational records via an interactive menu

## Testing
- python3 -m compileall genesis_archival_core.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb91160108332bb5b9bdd5640d783